### PR TITLE
refactor: fix incorrect use of greater for index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Swatches:** Greens, GreenAccents; LightGreens, LightGreenAccents; Teals,
     TealAccents.
 
+### Fixed
+- Incorrect use of the word _greater_ as comparative for _index_; replaced by _higher_.
+
 ## [0.0.8] - 2021-05-20
 ### Added
 - Amber, Lime, Yellow palettes and swatches - [#42](https://github.com/dartoos-dev/eo_color/issues/49).

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ ten shades of grey, as defined by the Material Design standard.
 
 These are classes whose name is the plural of a color, such as "Greys". For
 example: `Greys().colors` retrieves an `Iterable<Color>` containing ten shades
-of grey; the greater the index, the darker the color.
+of grey; the higher the index, the darker the color.
 
 #### Swatch in action
 

--- a/lib/src/material/amber/amber_accents.dart
+++ b/lib/src/material/amber/amber_accents.dart
@@ -7,7 +7,7 @@ import 'amber_accent.dart';
 /// See also
 /// - [amber accent](https://api.flutter.dev/flutter/material/Colors/amberAccent-constant.html)
 class AmberAccents extends SwatchBase {
-  /// Four shades of amber accent; the greater the index, the darker the color.
+  /// Four shades of amber accent; the higher the index, the darker the color.
   ///
   /// There are 4 valid indexes
   /// - 0, light ≡ 100

--- a/lib/src/material/amber/ambers.dart
+++ b/lib/src/material/amber/ambers.dart
@@ -7,7 +7,7 @@ import 'amber.dart';
 /// See also
 /// - [amber](https://api.flutter.dev/flutter/material/Colors/amber-constant.html)
 class Ambers extends SwatchBase {
-  /// Ten shades of amber; the greater the index, the darker the color.
+  /// Ten shades of amber; the higher the index, the darker the color.
   ///
   /// There are 10 valid indexes
   /// - 0, ultra light ≡ 50

--- a/lib/src/material/blue/blue_accents.dart
+++ b/lib/src/material/blue/blue_accents.dart
@@ -7,7 +7,7 @@ import 'blue_accent.dart';
 /// See also
 /// - [blue accent](https://api.flutter.dev/flutter/material/Colors/blueAccent-constant.html)
 class BlueAccents extends SwatchBase {
-  /// Four shades of blue accent; the greater the index, the darker the color.
+  /// Four shades of blue accent; the higher the index, the darker the color.
   ///
   /// There are 4 valid indexes
   /// - 0, light ≡ 100

--- a/lib/src/material/blue/blues.dart
+++ b/lib/src/material/blue/blues.dart
@@ -7,7 +7,7 @@ import 'blue.dart';
 /// See also
 /// - [blue](https://api.flutter.dev/flutter/material/Colors/blue-constant.html)
 class Blues extends SwatchBase {
-  /// Ten shades of blue; the greater the index, the darker the color.
+  /// Ten shades of blue; the higher the index, the darker the color.
   ///
   /// There are 10 valid indexes
   /// - 0, ultra light ≡ 50

--- a/lib/src/material/blue_grey/blue_greys.dart
+++ b/lib/src/material/blue_grey/blue_greys.dart
@@ -7,7 +7,7 @@ import 'blue_grey.dart';
 /// See also
 /// - [blue-grey](https://api.flutter.dev/flutter/material/Colors/blueGrey-constant.html)
 class BlueGreys extends SwatchBase {
-  /// Ten shades of blue-grey; the greater the index, the darker the color.
+  /// Ten shades of blue-grey; the higher the index, the darker the color.
   ///
   /// There are 10 valid indexes
   /// - 0, ultra light ≡ 50

--- a/lib/src/material/brown/browns.dart
+++ b/lib/src/material/brown/browns.dart
@@ -7,7 +7,7 @@ import 'brown.dart';
 /// See also
 /// - [brown](https://api.flutter.dev/flutter/material/Colors/brown-constant.html)
 class Browns extends SwatchBase {
-  /// Ten shades of brown; the greater the index, the darker the color.
+  /// Ten shades of brown; the higher the index, the darker the color.
   ///
   /// There are 10 valid indexes
   /// - 0, ultra light ≡ 50

--- a/lib/src/material/cyan/cyan_accents.dart
+++ b/lib/src/material/cyan/cyan_accents.dart
@@ -7,7 +7,7 @@ import 'cyan_accent.dart';
 /// See also
 /// - [cyan accent](https://api.flutter.dev/flutter/material/Colors/cyanAccent-constant.html)
 class CyanAccents extends SwatchBase {
-  /// Four shades of cyan accent; the greater the index, the darker the color.
+  /// Four shades of cyan accent; the higher the index, the darker the color.
   ///
   /// There are 4 valid indexes
   /// - 0, light ≡ 100

--- a/lib/src/material/cyan/cyans.dart
+++ b/lib/src/material/cyan/cyans.dart
@@ -7,7 +7,7 @@ import 'cyan.dart';
 /// See also
 /// - [cyan](https://api.flutter.dev/flutter/material/Colors/cyan-constant.html)
 class Cyans extends SwatchBase {
-  /// Ten shades of cyan; the greater the index, the darker the color.
+  /// Ten shades of cyan; the higher the index, the darker the color.
   ///
   /// There are 10 valid indexes
   /// - 0, ultra light ≡ 50

--- a/lib/src/material/deep_orange/deep_orange_accents.dart
+++ b/lib/src/material/deep_orange/deep_orange_accents.dart
@@ -7,7 +7,7 @@ import 'deep_orange_accent.dart';
 /// See also
 /// - [deep orange accent](https://api.flutter.dev/flutter/material/Colors/deep orangeAccent-constant.html)
 class DeepOrangeAccents extends SwatchBase {
-  /// Four shades of deep orange accent; the greater the index, the darker the color.
+  /// Four shades of deep orange accent; the higher the index, the darker the color.
   ///
   /// There are 4 valid indexes
   /// - 0, light ≡ 100

--- a/lib/src/material/deep_orange/deep_oranges.dart
+++ b/lib/src/material/deep_orange/deep_oranges.dart
@@ -7,7 +7,7 @@ import 'deep_orange.dart';
 /// See also
 /// - [deepOrange](https://api.flutter.dev/flutter/material/Colors/deepOrange-constant.html)
 class DeepOranges extends SwatchBase {
-  /// Ten shades of deep orange; the greater the index, the darker the color.
+  /// Ten shades of deep orange; the higher the index, the darker the color.
   ///
   /// There are 10 valid indexes
   /// - 0, ultra light ≡ 50

--- a/lib/src/material/deep_purple/deep_purple_accents.dart
+++ b/lib/src/material/deep_purple/deep_purple_accents.dart
@@ -7,7 +7,7 @@ import 'deep_purple_accent.dart';
 /// See also
 /// - [deep purple accent](https://api.flutter.dev/flutter/material/Colors/deepPurpleAccent-constant.html)
 class DeepPurpleAccents extends SwatchBase {
-  /// Four shades of deep purple accent; the greater the index, the darker the color.
+  /// Four shades of deep purple accent; the higher the index, the darker the color.
   ///
   /// There are 4 valid indexes
   /// - 0, light ≡ 100

--- a/lib/src/material/deep_purple/deep_purples.dart
+++ b/lib/src/material/deep_purple/deep_purples.dart
@@ -7,7 +7,7 @@ import 'deep_purple.dart';
 /// See also
 /// - [deep purple](https://api.flutter.dev/flutter/material/Colors/deepPurple-constant.html)
 class DeepPurples extends SwatchBase {
-  /// Ten shades of deep purple; the greater the index, the darker the color.
+  /// Ten shades of deep purple; the higher the index, the darker the color.
   ///
   /// There are 10 valid indexes
   /// - 0, ultra light ≡ 50

--- a/lib/src/material/green/green_accents.dart
+++ b/lib/src/material/green/green_accents.dart
@@ -7,7 +7,7 @@ import 'green_accent.dart';
 /// See also
 /// - [green accent](https://api.flutter.dev/flutter/material/Colors/greenAccent-constant.html)
 class GreenAccents extends SwatchBase {
-  /// Four shades of green accent; the greater the index, the darker the color.
+  /// Four shades of green accent; the higher the index, the darker the color.
   ///
   /// There are 4 valid indexes
   /// - 0, light ≡ 100

--- a/lib/src/material/green/greens.dart
+++ b/lib/src/material/green/greens.dart
@@ -7,7 +7,7 @@ import 'green.dart';
 /// See also
 /// - [green](https://api.flutter.dev/flutter/material/Colors/green-constant.html)
 class Greens extends SwatchBase {
-  /// Ten shades of green; the greater the index, the darker the color.
+  /// Ten shades of green; the higher the index, the darker the color.
   ///
   /// There are 10 valid indexes
   /// - 0, ultra light ≡ 50

--- a/lib/src/material/grey/greys.dart
+++ b/lib/src/material/grey/greys.dart
@@ -7,7 +7,7 @@ import 'grey.dart';
 /// See also
 /// - [grey](https://api.flutter.dev/flutter/material/Colors/grey-constant.html)
 class Greys extends SwatchBase {
-  /// Ten shades of grey; the greater the index, the darker the color.
+  /// Ten shades of grey; the higher the index, the darker the color.
   ///
   /// There are 10 valid indexes
   /// - 0, ultra light ≡ 50

--- a/lib/src/material/indigo/indigo_accents.dart
+++ b/lib/src/material/indigo/indigo_accents.dart
@@ -7,7 +7,7 @@ import 'indigo_accent.dart';
 /// See also
 /// - [indigo accent](https://api.flutter.dev/flutter/material/Colors/indigoAccent-constant.html)
 class IndigoAccents extends SwatchBase {
-  /// Four shades of indigo accent; the greater the index, the darker the color.
+  /// Four shades of indigo accent; the higher the index, the darker the color.
   ///
   /// There are 4 valid indexes
   /// - 0, light ≡ 100

--- a/lib/src/material/indigo/indigos.dart
+++ b/lib/src/material/indigo/indigos.dart
@@ -7,7 +7,7 @@ import 'indigo.dart';
 /// See also
 /// - [indigo](https://api.flutter.dev/flutter/material/Colors/indigo-constant.html)
 class Indigos extends SwatchBase {
-  /// Ten shades of indigo; the greater the index, the darker the color.
+  /// Ten shades of indigo; the higher the index, the darker the color.
   ///
   /// There are 10 valid indexes
   /// - 0, ultra light ≡ 50

--- a/lib/src/material/light_blue/light_blue_accents.dart
+++ b/lib/src/material/light_blue/light_blue_accents.dart
@@ -13,7 +13,7 @@ import 'light_blue_accent.dart';
 /// See also
 /// - [light blue accent](https://api.flutter.dev/flutter/material/Colors/lightBlueAccent-constant.html)
 class LightBlueAccents extends SwatchBase {
-  /// Four shades of light blue accent; the greater the index, the darker the color.
+  /// Four shades of light blue accent; the higher the index, the darker the color.
   ///
   /// There are 4 valid indexes
   /// - 0, light ≡ 100

--- a/lib/src/material/light_blue/light_blues.dart
+++ b/lib/src/material/light_blue/light_blues.dart
@@ -7,7 +7,7 @@ import 'light_blue.dart';
 /// See also
 /// - [lightBlue](https://api.flutter.dev/flutter/material/Colors/lightBlue-constant.html)
 class LightBlues extends SwatchBase {
-  /// Ten shades of light blue; the greater the index, the darker the color.
+  /// Ten shades of light blue; the higher the index, the darker the color.
   ///
   /// There are 10 valid indexes
   /// - 0, ultra light ≡ 50

--- a/lib/src/material/light_green/light_green_accents.dart
+++ b/lib/src/material/light_green/light_green_accents.dart
@@ -13,7 +13,7 @@ import 'light_green_accent.dart';
 /// See also
 /// - [light green accent](https://api.flutter.dev/flutter/material/Colors/lightGreenAccent-constant.html)
 class LightGreenAccents extends SwatchBase {
-  /// Four shades of light green accent; the greater the index, the darker the color.
+  /// Four shades of light green accent; the higher the index, the darker the color.
   ///
   /// There are 4 valid indexes
   /// - 0, light ≡ 100

--- a/lib/src/material/light_green/light_greens.dart
+++ b/lib/src/material/light_green/light_greens.dart
@@ -7,7 +7,7 @@ import 'light_green.dart';
 /// See also
 /// - [lightGreen](https://api.flutter.dev/flutter/material/Colors/lightGreen-constant.html)
 class LightGreens extends SwatchBase {
-  /// Ten shades of light green; the greater the index, the darker the color.
+  /// Ten shades of light green; the higher the index, the darker the color.
   ///
   /// There are 10 valid indexes
   /// - 0, ultra light ≡ 50

--- a/lib/src/material/lime/lime_accents.dart
+++ b/lib/src/material/lime/lime_accents.dart
@@ -7,7 +7,7 @@ import 'lime_accent.dart';
 /// See also
 /// - [lime accent](https://api.flutter.dev/flutter/material/Colors/limeAccent-constant.html)
 class LimeAccents extends SwatchBase {
-  /// Four shades of lime accent; the greater the index, the darker the color.
+  /// Four shades of lime accent; the higher the index, the darker the color.
   ///
   /// There are 4 valid indexes
   /// - 0, light ≡ 100

--- a/lib/src/material/lime/limes.dart
+++ b/lib/src/material/lime/limes.dart
@@ -7,7 +7,7 @@ import 'lime.dart';
 /// See also
 /// - [lime](https://api.flutter.dev/flutter/material/Colors/lime-constant.html)
 class Limes extends SwatchBase {
-  /// Ten shades of lime; the greater the index, the darker the color.
+  /// Ten shades of lime; the higher the index, the darker the color.
   ///
   /// There are 10 valid indexes
   /// - 0, ultra light ≡ 50

--- a/lib/src/material/orange/orange_accents.dart
+++ b/lib/src/material/orange/orange_accents.dart
@@ -7,7 +7,7 @@ import 'orange_accent.dart';
 /// See also
 /// - [orange accent](https://api.flutter.dev/flutter/material/Colors/orangeAccent-constant.html)
 class OrangeAccents extends SwatchBase {
-  /// Four shades of orange accent; the greater the index, the darker the color.
+  /// Four shades of orange accent; the higher the index, the darker the color.
   ///
   /// There are 4 valid indexes
   /// - 0, light ≡ 100

--- a/lib/src/material/orange/oranges.dart
+++ b/lib/src/material/orange/oranges.dart
@@ -7,7 +7,7 @@ import 'orange.dart';
 /// See also
 /// - [orange](https://api.flutter.dev/flutter/material/Colors/orange-constant.html)
 class Oranges extends SwatchBase {
-  /// Ten shades of orange; the greater the index, the darker the color.
+  /// Ten shades of orange; the higher the index, the darker the color.
   ///
   /// There are 10 valid indexes
   /// - 0, ultra light ≡ 50

--- a/lib/src/material/purple/purple_accents.dart
+++ b/lib/src/material/purple/purple_accents.dart
@@ -7,7 +7,7 @@ import 'purple_accent.dart';
 /// See also
 /// - [purple accent](https://api.flutter.dev/flutter/material/Colors/purpleAccent-constant.html)
 class PurpleAccents extends SwatchBase {
-  /// Four shades of purple accent; the greater the index, the darker the color.
+  /// Four shades of purple accent; the higher the index, the darker the color.
   ///
   /// There are 4 valid indexes
   /// - 0, light ≡ 100

--- a/lib/src/material/purple/purples.dart
+++ b/lib/src/material/purple/purples.dart
@@ -7,7 +7,7 @@ import 'purple.dart';
 /// See also
 /// - [purple](https://api.flutter.dev/flutter/material/Colors/purple-constant.html)
 class Purples extends SwatchBase {
-  /// Ten shades of purple; the greater the index, the darker the color.
+  /// Ten shades of purple; the higher the index, the darker the color.
   ///
   /// There are 10 valid indexes
   /// - 0, ultra light ≡ 50

--- a/lib/src/material/teal/teal_accents.dart
+++ b/lib/src/material/teal/teal_accents.dart
@@ -7,7 +7,7 @@ import 'teal_accent.dart';
 /// See also
 /// - [teal accent](https://api.flutter.dev/flutter/material/Colors/tealAccent-constant.html)
 class TealAccents extends SwatchBase {
-  /// Four shades of teal accent; the greater the index, the darker the color.
+  /// Four shades of teal accent; the higher the index, the darker the color.
   ///
   /// There are 4 valid indexes
   /// - 0, light ≡ 100

--- a/lib/src/material/teal/teals.dart
+++ b/lib/src/material/teal/teals.dart
@@ -7,7 +7,7 @@ import 'teal.dart';
 /// See also
 /// - [teal](https://api.flutter.dev/flutter/material/Colors/teal-constant.html)
 class Teals extends SwatchBase {
-  /// Ten shades of teal; the greater the index, the darker the color.
+  /// Ten shades of teal; the higher the index, the darker the color.
   ///
   /// There are 10 valid indexes
   /// - 0, ultra light ≡ 50

--- a/lib/src/material/yellow/yellow_accents.dart
+++ b/lib/src/material/yellow/yellow_accents.dart
@@ -7,7 +7,7 @@ import 'yellow_accent.dart';
 /// See also
 /// - [yellow accent](https://api.flutter.dev/flutter/material/Colors/yellowAccent-constant.html)
 class YellowAccents extends SwatchBase {
-  /// Four shades of yellow accent; the greater the index, the darker the color.
+  /// Four shades of yellow accent; the higher the index, the darker the color.
   ///
   /// There are 4 valid indexes
   /// - 0, light ≡ 100

--- a/lib/src/material/yellow/yellows.dart
+++ b/lib/src/material/yellow/yellows.dart
@@ -7,7 +7,7 @@ import 'yellow.dart';
 /// See also
 /// - [yellow](https://api.flutter.dev/flutter/material/Colors/yellow-constant.html)
 class Yellows extends SwatchBase {
-  /// Ten shades of yellow; the greater the index, the darker the color.
+  /// Ten shades of yellow; the higher the index, the darker the color.
   ///
   /// There are 10 valid indexes
   /// - 0, ultra light ≡ 50


### PR DESCRIPTION
The proper comparative for _index_ is _higher_, not _greater_.

Closes #55