### PR TITLE
refactor: stricter lint rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Stricter lint rules - [#71](https://github.com/dartoos-dev/eo_color/issues/71).
 
 ## [0.0.12] - 2021-05-25
 ### Added

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -3,3 +3,7 @@ linter:
   rules:
     # Always await.
     unawaited_futures: true
+    # Make constructors the first thing in every class
+    sort_constructors_first: true
+    # Good packages document everything
+    public_member_api_docs: true

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -49,7 +49,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.7"
+    version: "0.0.12"
   fake_async:
     dependency: transitive
     description:


### PR DESCRIPTION
The added rules are:    

 - sort_constructors_first: true - make constructors the first thing in every class
 - public_member_api_docs: true - good packages document everything
